### PR TITLE
Instances if

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/CSharpAsyncCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/CSharpAsyncCompiler.scala
@@ -298,8 +298,10 @@ class CSharpAsyncCompiler(val typeProvider: ClassTypeProvider, config: RuntimeCo
   }
 
   override def condIfFooter(expr: expr): Unit = {
+    out.dec
     out.puts("}")
-    out.puts("else {")
+    out.puts("else")
+    out.puts("{")
     out.inc
     out.puts(s"""throw new InvalidOperationException("Else branch hit on condition \\"${expr}\\"");""");
     out.dec

--- a/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/components/LanguageCompiler.scala
@@ -103,6 +103,9 @@ abstract class LanguageCompiler(
   def condIfHeader(expr: Ast.expr): Unit
   def condIfFooter(expr: Ast.expr): Unit
 
+  // allows generating footer that signals error
+  def condIfFooterWithErrorSignalingElse(expr: Ast.expr): Unit = condIfFooter(expr)
+
   def condRepeatEosHeader(id: Identifier, io: String, dataType: DataType, needRaw: Boolean): Unit
   def condRepeatEosFooter: Unit
 
@@ -154,6 +157,13 @@ abstract class LanguageCompiler(
   def attrParseIfFooter(ifExpr: Option[Ast.expr]): Unit = {
     ifExpr match {
       case Some(e) => condIfFooter(e)
+      case None => // ignore
+    }
+  }
+
+  def attrParseIfFooterWithErrorSignalingElse(ifExpr: Option[Ast.expr]): Unit = {
+    ifExpr match {
+      case Some(e) => condIfFooterWithErrorSignalingElse(e)
       case None => // ignore
     }
   }


### PR DESCRIPTION
- Pro [parse instances](http://doc.kaitai.io/user_guide.html#_instances_data_beyond_the_sequence)  generuje `if` bez `else` větve
- Všude jinde generuje else větev, která háže vyjímku
- [Value instances](http://doc.kaitai.io/user_guide.html#_value_instances) neřeší, protože neznám použití. Podle té dokumentace dokonce podporuje jen `value` klíč, ale v [kompilátoru](https://github.com/pluskal/kaitai_struct_compiler/blob/Async/shared/src/main/scala/io/kaitai/struct/format/InstanceSpec.scala#L10) to umí i `if`. Teď to bude vyhazovat vyjímky v `else`, což bude asi lepší výchozí přístup, když děláme konzervativní verzi.